### PR TITLE
feat: automate cloud9 detection and config

### DIFF
--- a/ansible/jonzeolla/labs/roles/cloud9/tasks/main.yml
+++ b/ansible/jonzeolla/labs/roles/cloud9/tasks/main.yml
@@ -1,6 +1,18 @@
 ---
+- name: Gather info needed to detect Cloud9 images
+  block:
+    - name: Gather EC2 metadata facts
+      amazon.aws.ec2_metadata_facts:
+
+    - name: Gather AMI details
+      amazon.aws.ec2_ami_info:
+        image_ids: "{{ ansible_ec2_ami_id }}"
+
 - name: Resize the host disk to 40 GiB
-  when: "lookup('ansible.builtin.env', 'C9_PROJECT', default='') | length > 0"
+  when:  >
+    ec2_ami_facts['images'][0]['image_location'].startswith('amazon/Cloud9') and
+    ec2_ami_facts['images'][0]['name'].startswith('Cloud9') and
+    ec2_ami_facts['images'][0]['owner_id'] == '845575274112'
   block:
     - name: Transfer resize script
       ansible.builtin.copy:

--- a/ansible/jonzeolla/labs/roles/cloud9/tasks/main.yml
+++ b/ansible/jonzeolla/labs/roles/cloud9/tasks/main.yml
@@ -9,7 +9,7 @@
         image_ids: "{{ ansible_ec2_ami_id }}"
 
 - name: Resize the host disk to 40 GiB
-  when:  >
+  when: >
     ec2_ami_facts['images'][0]['image_location'].startswith('amazon/Cloud9') and
     ec2_ami_facts['images'][0]['name'].startswith('Cloud9') and
     ec2_ami_facts['images'][0]['owner_id'] == '845575274112'

--- a/ansible/jonzeolla/labs/roles/gitlab/tasks/main.yml
+++ b/ansible/jonzeolla/labs/roles/gitlab/tasks/main.yml
@@ -6,6 +6,10 @@
     fail_msg: "This playbook only supports Debian and RedHat based systems."
   run_once: true
 
+- name: Detect and setup Cloud9 as needed
+  ansible.builtin.include_role:
+    name: jonzeolla.labs.cloud9
+
 - name: Run docker_compose role
   ansible.builtin.include_role:
     name: docker_compose


### PR DESCRIPTION
Two improvements to upstream projects: (1) we no longer need to pass in any specific `C9_` env vars, shortening the `docker run` command, and (2) Cloud9 is no longer an explicit reference.  You just include the gitlab role (directly or indirectly), and it will setup cloud9 as needed.