### PR TITLE
Reduce cloud9 usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ git push --atomic origin $(git branch --show-current) --follow-tags
 
 ## Troubleshooting
 
-If you want to troubleshoot issues using this as a part of a workshop, create a Cloud9 environment, clone the repository that uses this project (i.e.
-`policy-as-code`), run `task init` or `git submodule update --init --recursive` from inside that repository folder, and then run the following:
+If you want to troubleshoot issues using this as a part of a workshop, clone the repository that uses this project (i.e. `policy-as-code`), run `task init` or
+`git submodule update --init --recursive` from inside that repository folder, and then run the following:
 
 ```bash
 repository=policy-as-code
-role=cloud9
+role=gitlab
 docker run -v ~/environment/${repository}/lab-resources/ansible/jonzeolla/labs/roles/${role}/tasks/main.yml:/root/.ansible/collections/ansible_collections/jonzeolla/labs/roles/${role}/tasks/main.yml --network host -v /:/host jonzeolla/labs:${repository}
 ```

--- a/ansible/jonzeolla/labs/roles/docker/tasks/main.yml
+++ b/ansible/jonzeolla/labs/roles/docker/tasks/main.yml
@@ -61,10 +61,6 @@
     # Necessary due to curl/curl-minimal. skip_broken wasn't sufficient
     allowerasing: true
 
-- name: Detect and setup Cloud9 as needed
-  ansible.builtin.include_role:
-    name: jonzeolla.labs.cloud9
-
 - name: Download get-docker.sh
   ansible.builtin.get_url:
     url: https://get.docker.com

--- a/ansible/jonzeolla/labs/roles/gitlab/tasks/main.yml
+++ b/ansible/jonzeolla/labs/roles/gitlab/tasks/main.yml
@@ -6,10 +6,6 @@
     fail_msg: "This playbook only supports Debian and RedHat based systems."
   run_once: true
 
-- name: Detect and setup Cloud9 as needed
-  ansible.builtin.include_role:
-    name: jonzeolla.labs.cloud9
-
 - name: Run docker_compose role
   ansible.builtin.include_role:
     name: docker_compose


### PR DESCRIPTION
This reduces cloud9 usage by other roles. Cloud9 is no longer a first class citizen in AWS so we're moving to bare EC2s