### PR TITLE
chore: incrementally support debian better

### DIFF
--- a/ansible/jonzeolla/labs/roles/docker/tasks/main.yml
+++ b/ansible/jonzeolla/labs/roles/docker/tasks/main.yml
@@ -18,21 +18,6 @@
     update_cache: true
     install_recommends: no
 
-- name: Install prereqs
-  become: true
-  when: >
-    ansible_os_family == 'RedHat' and
-    ansible_distribution == 'Amazon' and
-    ansible_distribution_version == '2' and
-    ansible_python_version is ansible.builtin.version('2.7', '<=')
-  ansible.builtin.yum:
-    name:
-      - ca-certificates
-      - curl
-      - jq
-      - sudo
-    state: latest
-
 - name: >
     Install via command on Amazon Linux 2 due to a lack of dnf, and
     that ansible.builtin.yum only works with python 2.7

--- a/ansible/jonzeolla/labs/roles/homebrew/tasks/main.yml
+++ b/ansible/jonzeolla/labs/roles/homebrew/tasks/main.yml
@@ -2,8 +2,8 @@
 - name: Ensure supported OS
   ansible.builtin.assert:
     that:
-      - ansible_os_family in ['RedHat']
-    fail_msg: "This playbook only supports RedHat based systems."
+      - ansible_os_family in ['RedHat', 'Debian']
+    fail_msg: "This playbook only supports RedHat or Debian based systems."
   run_once: true
 
 - name: Install prereqs (apt)
@@ -66,14 +66,6 @@
         src: /home/linuxbrew/.linuxbrew/bin/brew
         dest: "{{ home_dir }}/bin/brew"
         state: link
-    - name: Install homebrew runtime dependencies
-      become: true
-      when: >
-        ansible_os_family == 'RedHat' and
-        ansible_python_version is ansible.builtin.version('2.7', '<=')
-      ansible.builtin.yum:
-        name: '@Development Tools'
-        state: latest
     - name: Install homebrew runtime dependencies
       become: true
       when: >


### PR DESCRIPTION
This isn't meant to be complete, just something I had locally to make progress

This also starts to deprecate support for python 2.7, which is standard (🤮) for ansible on Amazon Linux 2